### PR TITLE
fixed typo + added link to subreddits file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Add subreddit links
 
-To add a new subreddit or links for an exisisting one, edit `./data/subrredits.json` and add a new object
+To add a new subreddit or links for an exisisting one, edit [`./data/subreddits.json`](data/subreddits.json) and add a new object
 to the `subs` array. The object should have the following properties:
 
 ```json


### PR DESCRIPTION
I noticed a minor typo in the README for the `subreddits.json` file and went ahead and fixed it.
I also added a link to the filename to link directly to the `subreddits.json` file that works both in the editor and in the GitHub UI.