### PR TITLE
Update r/nyc's Discord invite url

### DIFF
--- a/data/subreddits.json
+++ b/data/subreddits.json
@@ -1110,7 +1110,7 @@
       "links": [
         {
           "service": "discord",
-          "url": "https://discord.gg/newyorkcity",
+          "url": "https://discord.gg/AjvMEc97CR",
           "official": true,
           "added_ts": 1687119835162
         },


### PR DESCRIPTION
Our old custom server invite link is no longer accurate, so I [a moderator for the Discord server] created a new, permanent non-expiring invite that can be found [here](https://discord.gg/AjvMEc97CR).

This leads to the same Discord server that is linked on r/nyc itself, verify by either going to the subreddit or [clicking here](https://discord.gg/Mp6wmPB) for the invite listed on the subreddit.

![ed5090d4-4a64-488a-945a-b03dc37109fe](https://github.com/GeorgeSG/sub.rehab/assets/6139999/d115fcba-e5bf-48f5-a6bc-85f9678533df)
